### PR TITLE
Widen content layout

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -18,9 +18,9 @@
 
 .page {
   @include breakpoint($large) {
-    @include span(10 of 12 last);
-    @include prefix(0.5 of 12);
-    @include suffix(2 of 12);
+    @include span(12 of 12);
+    @include prefix(0);
+    @include suffix(0);
   }
 
   .page__inner-wrap {
@@ -49,9 +49,9 @@
 }
 
 .page__content {
-  max-width: 800px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 1.5em 2em;
+  padding: 1.25em 1.5em;
 
   @include breakpoint(max-width $medium) {
     padding: 1em 1.5em;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -113,8 +113,8 @@ $x-large                    : 1800px;
 $small                      : 600px !default;
 $medium                     : 768px !default;
 $medium-wide                : 900px !default;
-$large                      : 925px !default;
-$x-large                    : 1280px !default;
+$large                      : 1100px !default;
+$x-large                    : 1440px !default;
 
 /*
    Grid


### PR DESCRIPTION
## Summary
- expand the page layout to use the full grid width and reduce side padding
- increase page content maximum width and container breakpoints for a wider display

## Testing
- bundle exec jekyll build --config _config.yml *(fails: `jekyll` executable not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375c31c4408325a2186cd8883c2a9c)