### PR TITLE
Broaden page layout width

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -18,9 +18,9 @@
 
 .page {
   @include breakpoint($large) {
-    @include span(10 of 12 last);
-    @include prefix(0.5 of 12);
-    @include suffix(2 of 12);
+    @include span(12 of 12);
+    @include prefix(0);
+    @include suffix(0);
   }
 
   .page__inner-wrap {
@@ -49,12 +49,12 @@
 }
 
 .page__content {
-  max-width: 800px;
+  max-width: 1600px;
   margin: 0 auto;
-  padding: 1.5em 2em;
+  padding: 1.1em 1.25em;
 
   @include breakpoint(max-width $medium) {
-    padding: 1em 1.5em;
+    padding: 1em 1.25em;
   }
 
   @include breakpoint(max-width $small) {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -113,8 +113,8 @@ $x-large                    : 1800px;
 $small                      : 600px !default;
 $medium                     : 768px !default;
 $medium-wide                : 900px !default;
-$large                      : 925px !default;
-$x-large                    : 1280px !default;
+$large                      : 1400px !default;
+$x-large                    : 2000px !default;
 
 /*
    Grid
@@ -131,7 +131,7 @@ $susy: (
   math: fluid,
   output: float,
   gutter-position: after,
-  container: $large,
+  container: $x-large,
   global-box-sizing: border-box,
   // debug: (
   //   image: show,


### PR DESCRIPTION
## Summary
- increase site container and breakpoint widths to reduce side margins
- widen page content area and slightly trim padding for posts and pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375c31c4408325a2186cd8883c2a9c)