### PR TITLE
Fix tag filtering compatibility in posts archive

### DIFF
--- a/_pages/year-archive.html
+++ b/_pages/year-archive.html
@@ -49,11 +49,11 @@ redirect_from:
   'use strict';
   
   function init() {
-    const tagButtons = document.querySelectorAll('.tag-filter-btn');
+    const tagButtons = Array.prototype.slice.call(document.querySelectorAll('.tag-filter-btn'));
     const clearButton = document.getElementById('clear-filters');
     const activeFiltersEl = document.getElementById('active-filters');
-    const postItems = document.querySelectorAll('.post-item');
-    const yearHeaders = document.querySelectorAll('.year-header');
+    const postItems = Array.prototype.slice.call(document.querySelectorAll('.post-item'));
+    const yearHeaders = Array.prototype.slice.call(document.querySelectorAll('.year-header'));
     let selectedTags = new Set();
 
     function updateActiveFilters() {


### PR DESCRIPTION
## Summary
- convert tag filter node lists to arrays to support browsers without NodeList.forEach
- ensure tag filter controls properly attach event listeners in the posts archive

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938619f480c832587488a823a970322)