### PR TITLE
Improve tag filter compatibility

### DIFF
--- a/_pages/year-archive.html
+++ b/_pages/year-archive.html
@@ -16,11 +16,11 @@ redirect_from:
     {% if all_tags.size > 0 %}
       {% for tag in all_tags %}
         {% if tag != nil and tag != '' %}
-          <button class="btn btn--primary tag-filter-btn" data-tag="{{ tag | slugify }}" style="margin: 0.25em;">{{ tag }}</button>
+          <button class="btn btn--primary tag-filter-btn" type="button" data-tag="{{ tag | slugify }}" style="margin: 0.25em;">{{ tag }}</button>
         {% endif %}
       {% endfor %}
     {% endif %}
-    <button class="btn btn--primary tag-filter-btn" id="clear-filters" style="margin: 0.25em;">Clear All</button>
+    <button class="btn btn--primary tag-filter-btn" type="button" id="clear-filters" style="margin: 0.25em;">Clear All</button>
   </p>
   <p id="active-filters" style="margin-top: 1em; font-style: italic; color: #666;"></p>
 </div>
@@ -49,19 +49,19 @@ redirect_from:
   'use strict';
   
   function init() {
-    const tagButtons = document.querySelectorAll('.tag-filter-btn');
-    const clearButton = document.getElementById('clear-filters');
-    const activeFiltersEl = document.getElementById('active-filters');
-    const postItems = document.querySelectorAll('.post-item');
-    const yearHeaders = document.querySelectorAll('.year-header');
-    let selectedTags = new Set();
+    var tagButtons = Array.prototype.slice.call(document.querySelectorAll('.tag-filter-btn'));
+    var clearButton = document.getElementById('clear-filters');
+    var activeFiltersEl = document.getElementById('active-filters');
+    var postItems = Array.prototype.slice.call(document.querySelectorAll('.post-item'));
+    var yearHeaders = Array.prototype.slice.call(document.querySelectorAll('.year-header'));
+    var selectedTags = [];
 
     function updateActiveFilters() {
       if (!activeFiltersEl) return;
-      if (selectedTags.size === 0) {
+      if (selectedTags.length === 0) {
         activeFiltersEl.textContent = '';
       } else {
-        activeFiltersEl.textContent = 'Active filters: ' + Array.from(selectedTags).join(', ');
+        activeFiltersEl.textContent = 'Active filters: ' + selectedTags.join(', ');
       }
     }
 
@@ -69,16 +69,23 @@ redirect_from:
       if (!postItems || postItems.length === 0) return;
       
       postItems.forEach(function(post) {
-        const tagsAttr = post.getAttribute('data-tags');
+        var tagsAttr = post.getAttribute('data-tags');
         if (!tagsAttr || tagsAttr.trim() === '') {
-          post.style.display = selectedTags.size === 0 ? '' : 'none';
+          post.style.display = selectedTags.length === 0 ? '' : 'none';
           return;
         }
-        
-        const postTags = tagsAttr.trim().split(/\s+/).filter(function(t) { return t.length > 0; });
-        const hasAllTags = selectedTags.size === 0 || Array.from(selectedTags).every(function(tag) {
-          return postTags.indexOf(tag) !== -1;
-        });
+
+        var postTags = tagsAttr.trim().split(/\s+/).filter(function(t) { return t.length > 0; });
+        var hasAllTags = true;
+
+        if (selectedTags.length > 0) {
+          for (var i = 0; i < selectedTags.length; i++) {
+            if (postTags.indexOf(selectedTags[i]) === -1) {
+              hasAllTags = false;
+              break;
+            }
+          }
+        }
         
         if (hasAllTags) {
           post.style.display = '';
@@ -90,11 +97,11 @@ redirect_from:
       // Hide year headers if no posts are visible in that year
       if (yearHeaders && yearHeaders.length > 0) {
         yearHeaders.forEach(function(header) {
-          const year = header.getAttribute('data-year');
-          let hasVisiblePosts = false;
+          var year = header.getAttribute('data-year');
+          var hasVisiblePosts = false;
           
           // Find the next sibling post items after this header
-          let current = header.nextElementSibling;
+          var current = header.nextElementSibling;
           while (current) {
             if (current.classList && current.classList.contains('post-item')) {
               if (current.style.display !== 'none') {
@@ -107,7 +114,7 @@ redirect_from:
             current = current.nextElementSibling;
           }
           
-          if (!hasVisiblePosts && selectedTags.size > 0) {
+          if (!hasVisiblePosts && selectedTags.length > 0) {
             header.style.display = 'none';
           } else {
             header.style.display = '';
@@ -120,13 +127,14 @@ redirect_from:
       tagButtons.forEach(function(btn) {
         if (btn.id !== 'clear-filters') {
           btn.addEventListener('click', function() {
-            const tag = this.getAttribute('data-tag');
-            
-            if (selectedTags.has(tag)) {
-              selectedTags.delete(tag);
+            var tag = this.getAttribute('data-tag');
+            var tagIndex = selectedTags.indexOf(tag);
+
+            if (tagIndex !== -1) {
+              selectedTags.splice(tagIndex, 1);
               this.classList.remove('active');
             } else {
-              selectedTags.add(tag);
+              selectedTags.push(tag);
               this.classList.add('active');
             }
             
@@ -139,7 +147,7 @@ redirect_from:
 
     if (clearButton) {
       clearButton.addEventListener('click', function() {
-        selectedTags.clear();
+        selectedTags = [];
         if (tagButtons && tagButtons.length > 0) {
           tagButtons.forEach(function(btn) {
             btn.classList.remove('active');


### PR DESCRIPTION
## Summary
- add button types and legacy-compatible JS for tag filtering on the posts archive
- replace modern language features with broadly supported alternatives to ensure event handlers and filtering work reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938619f480c832587488a823a970322)